### PR TITLE
feat: add docker volume for database

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,6 +36,8 @@ services:
             POSTGRES_DB: litellm
             POSTGRES_USER: llmproxy
             POSTGRES_PASSWORD: dbpassword9090
+        volumes:
+            - db-storage:/var/lib/postgresql/data
         healthcheck:
             test: ["CMD-SHELL", "pg_isready -d litellm -U llmproxy"]
             interval: 1s
@@ -44,3 +46,4 @@ services:
 
 volumes:
     open-webui:
+    db-storage:


### PR DESCRIPTION
Hi!

Thank you for this ready to go project. I was looking for a setup just like yours to quickly set up Open WebUI with LiteLLM.

While setting everything up I've noticed that models added from the LiteLLM UI where getting lost when rebooting the containers because the database wasn't persisted.

I've added a volume that is being used by the postgres service in my local copy and thought you also might find this useful :)